### PR TITLE
Show priority pill and created time on kanban cards

### DIFF
--- a/apps/web/src/components/monitor/KanbanBoard.tsx
+++ b/apps/web/src/components/monitor/KanbanBoard.tsx
@@ -13,6 +13,7 @@ import {
 } from "@dnd-kit/core";
 import { Plus } from "@phosphor-icons/react/Plus";
 import { MagicWandIcon } from "@phosphor-icons/react/MagicWand";
+import { PriorityIcon, PRIORITIES } from "./priority";
 import { trpc } from "../../lib/trpc";
 import { COLUMNS, canTransition } from "./columns";
 import { CreateItemDialog } from "./CreateItemDialog";
@@ -41,6 +42,22 @@ function useCollapsedColumns() {
 
 function canDrop(fromStatus: string, toStatus: TaskStatus): boolean {
   return canTransition(fromStatus, toStatus);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatRelativeTime(date: Date) {
+  const now = Date.now();
+  const ms = now - new Date(date).getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(date).toLocaleDateString();
 }
 
 // ── Draggable card ──────────────────────────────────────────────────────────
@@ -77,6 +94,20 @@ function DraggableCard({
         task.status === "done" ? "text-muted-foreground line-through" : "text-foreground hover:underline"
       }`}>
         {task.title}
+      </p>
+      {task.priority && task.priority !== "none" && (() => {
+        const p = PRIORITIES.find((pr) => pr.value === task.priority);
+        return p ? (
+          <div className="flex flex-wrap gap-1.5 mt-0.5">
+            <span className={`inline-flex items-center gap-1 rounded-full border border-current/10 bg-current/5 px-2 py-0.5 text-xs ${p.color}`}>
+              <PriorityIcon level={p.value} className="size-3" />
+              {p.label}
+            </span>
+          </div>
+        ) : null;
+      })()}
+      <p className="text-xs text-muted-foreground mt-0.5">
+        {formatRelativeTime(task.createdAt)}
       </p>
     </div>
   );

--- a/apps/web/src/components/monitor/MonitorItemSheet.tsx
+++ b/apps/web/src/components/monitor/MonitorItemSheet.tsx
@@ -8,6 +8,7 @@ import { PaperPlaneTilt } from "@phosphor-icons/react/PaperPlaneTilt";
 import { Plus } from "@phosphor-icons/react/Plus";
 import { Robot } from "@phosphor-icons/react/Robot";
 import { Trash } from "@phosphor-icons/react/Trash";
+import { PriorityIcon, PRIORITIES } from "./priority";
 import { User } from "@phosphor-icons/react/User";
 import { X } from "@phosphor-icons/react/X";
 import { Markdown } from "../common/Markdown";
@@ -129,35 +130,6 @@ function SheetHeader({ item }: { item: MonitorItem }) {
 
 // ── Right sidebar ───────────────────────────────────────────────────────
 
-function PriorityIcon({ level, className = "" }: { level: string; className?: string }) {
-  if (level === "critical") {
-    return (
-      <svg viewBox="0 0 16 16" className={`size-4 ${className}`} fill="none">
-        <rect x="2" y="2" width="12" height="12" rx="2" fill="currentColor" opacity="0.2" />
-        <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.5" />
-        <line x1="8" y1="5" x2="8" y2="9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        <circle cx="8" cy="11" r="0.75" fill="currentColor" />
-      </svg>
-    );
-  }
-  // Bar chart icon — bars filled based on level
-  const bars = level === "high" ? 3 : level === "medium" ? 2 : level === "low" ? 1 : 0;
-  return (
-    <svg viewBox="0 0 16 16" className={`size-4 ${className}`} fill="none">
-      <rect x="2" y="10" width="3" height="4" rx="0.5" fill="currentColor" opacity={bars >= 1 ? 1 : 0.2} />
-      <rect x="6.5" y="6.5" width="3" height="7.5" rx="0.5" fill="currentColor" opacity={bars >= 2 ? 1 : 0.2} />
-      <rect x="11" y="3" width="3" height="11" rx="0.5" fill="currentColor" opacity={bars >= 3 ? 1 : 0.2} />
-    </svg>
-  );
-}
-
-const PRIORITIES = [
-  { value: "none", label: "No priority", color: "text-zinc-500" },
-  { value: "low", label: "Low", color: "text-zinc-400" },
-  { value: "medium", label: "Medium", color: "text-amber-400" },
-  { value: "high", label: "High", color: "text-orange-400" },
-  { value: "critical", label: "Critical", color: "text-red-400" },
-] as const;
 
 function Sidebar({
   item,

--- a/apps/web/src/components/monitor/priority.tsx
+++ b/apps/web/src/components/monitor/priority.tsx
@@ -1,0 +1,29 @@
+export function PriorityIcon({ level, className = "" }: { level: string; className?: string }) {
+  if (level === "critical") {
+    return (
+      <svg viewBox="0 0 16 16" className={`size-4 ${className}`} fill="none">
+        <rect x="2" y="2" width="12" height="12" rx="2" fill="currentColor" opacity="0.2" />
+        <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="8" y1="5" x2="8" y2="9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <circle cx="8" cy="11" r="0.75" fill="currentColor" />
+      </svg>
+    );
+  }
+  // Bar chart icon — bars filled based on level
+  const bars = level === "high" ? 3 : level === "medium" ? 2 : level === "low" ? 1 : 0;
+  return (
+    <svg viewBox="0 0 16 16" className={`size-4 ${className}`} fill="none">
+      <rect x="2" y="10" width="3" height="4" rx="0.5" fill="currentColor" opacity={bars >= 1 ? 1 : 0.2} />
+      <rect x="6.5" y="6.5" width="3" height="7.5" rx="0.5" fill="currentColor" opacity={bars >= 2 ? 1 : 0.2} />
+      <rect x="11" y="3" width="3" height="11" rx="0.5" fill="currentColor" opacity={bars >= 3 ? 1 : 0.2} />
+    </svg>
+  );
+}
+
+export const PRIORITIES = [
+  { value: "none", label: "No priority", color: "text-zinc-500" },
+  { value: "low", label: "Low", color: "text-zinc-400" },
+  { value: "medium", label: "Medium", color: "text-amber-400" },
+  { value: "high", label: "High", color: "text-orange-400" },
+  { value: "critical", label: "Critical", color: "text-red-400" },
+] as const;


### PR DESCRIPTION
## Summary
- Extracts `PriorityIcon` and `PRIORITIES` into a shared `priority.tsx` module, used by both kanban cards and the item detail sheet
- Displays a color-coded priority pill (icon + label) below the card title when priority is set
- Shows a relative timestamp ("3h ago", "2d ago", etc.) at the bottom of each card